### PR TITLE
fix: cursor 'move' starts from the first cent and jumps to after the collon

### DIFF
--- a/src/implanter.js
+++ b/src/implanter.js
@@ -61,7 +61,7 @@ module.exports = {
 
       if (input.maskArgs.cursor === 'start') {
         newCaretPosition = 0;
-      } else if (input.maskArgs.cursor === 'end') {
+      } else if (input.maskArgs.cursor === 'end' || (input.maskArgs.cursor === 'move' && oldValue.length <= 1)) {
         newCaretPosition = newValue.length;
       }
 


### PR DESCRIPTION
when an input starts empty '' or 1 char length, the newCaretPosition taken in place will be the size of the input. This avoids the cursor from jumping before the first mask is formatted.