### PR TITLE
[#56] Fixed typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.1",
   "description": "Simple money mask developed with pure JavaScript. To run on Client Side and Server Side",
   "main": "lib/simple-mask-money.js",
+  "types": "types/simple-mask-money.d.ts",
   "scripts": {
     "test:tdd": "npx mocha tests/**/*.test.js --require babel-register -w -b",
     "test": "npx mocha tests/**/*.test.js --require babel-register",

--- a/types/simple-mask-money.d.ts
+++ b/types/simple-mask-money.d.ts
@@ -1,26 +1,26 @@
 interface ISimpleMaskMoneyArgs {
-  afterFormat: (e: string) => {}; 
-  allowNegative: boolean = false;  
-  beforeFormat: (e: string) => {};  
-  negativeSignAfter: boolean = false;
-  decimalSeparator: string = ',';
-  fixed: boolean = true;
-  fractionDigits: number = 2;
+  afterFormat: (e: string) => {};
+  allowNegative: boolean;
+  beforeFormat: (e: string) => {};
+  negativeSignAfter: boolean;
+  decimalSeparator: string;
+  fixed: boolean;
+  fractionDigits: number;
   prefix: string;
   suffix: string;
-  thousandsSeparator: string = '.';
+  thousandsSeparator: string;
   cursor: 'start' | 'move' | 'end';
 }
 
-interface ISimpleMaskMoney {
-  public static args: ISimpleMaskMoneyArgs;
-  public static formatToCurrency(value: number, args?: ISimpleMaskMoneyArgs): string;
-  public static formatToMask(value: number, args?: ISimpleMaskMoneyArgs): string;
-  public static formatToNumber(value: string, args?: ISimpleMaskMoneyArgs): number;
-  public static setMask(element: string | HTMLInputElement, args?: ISimpleMaskMoneyArgs): HTMLInputElement;
+declare class SimpleMaskMoney {
+  static args: ISimpleMaskMoneyArgs;
+  static formatToCurrency(value: number | string, args?: ISimpleMaskMoneyArgs): string;
+  static formatToMask(value: number | string, args?: ISimpleMaskMoneyArgs): string;
+  static formatToNumber(value: string, args?: ISimpleMaskMoneyArgs): number;
+  static setMask(element: string | HTMLInputElement, args?: ISimpleMaskMoneyArgs): HTMLInputElement;
 }
 
 declare module 'simple-mask-money' {
-  export = ISimpleMaskMoney;
+  export = SimpleMaskMoney;
 }
 


### PR DESCRIPTION
resolve codermarcos/simple-mask-money#56

I've adjusted the type definitions for the `SimpleMaskMoney#{formatToCurrency,formatToMask}` methods to be more permissive than the original definitions for compatibility. If you have any concerns, please feel free to comment.
