### PR TITLE
🐛 Fix problem with space in prefix

### DIFF
--- a/cypress/e2e/v4.x.x/set-mask.cy.ts
+++ b/cypress/e2e/v4.x.x/set-mask.cy.ts
@@ -257,80 +257,167 @@ describe(
 describe(
   'prefix and suffix',
   () => {
-    beforeEach(
+    describe(
+      'common behaviour',
       () => {
-        cy.visit(getUrl({ prefix: '$', suffix: 'CAD' }));
-        cy.reload();
+        beforeEach(
+          () => {
+            cy.visit(getUrl({ prefix: '$', suffix: 'CAD' }));
+            cy.reload();
+          }
+        );
+    
+        it(
+          'should format when input was created',
+          () => {
+            cy.get('input').should('have.value', '$0,00CAD');
+          }
+        );
+    
+        it(
+          'shouldn\'t allow type a letter',
+          () => {
+            cy.get('input').type('abc');
+            cy.get('input').should('have.value', '$0,00CAD');
+          }
+        );
+    
+        it(
+          'should format when type only cents',
+          () => {
+            cy.get('input').type('1');
+            cy.get('input').should('have.value', '$0,01CAD');
+    
+            cy.get('input').type('{backspace}');
+            cy.get('input').should('have.value', '$0,00CAD');
+    
+            cy.get('input').type('12');
+            cy.get('input').should('have.value', '$0,12CAD');
+    
+            cy.get('input').type('{backspace}'.repeat(2));
+            cy.get('input').should('have.value', '$0,00CAD');
+    
+            cy.get('input').type('66');
+            cy.get('input').should('have.value', '$0,66CAD');
+          }
+        );
+    
+        it(
+          'should format dozens',
+          () => {
+            cy.get('input').type('123');
+            cy.get('input').should('have.value', '$1,23CAD');
+    
+    
+            cy.get('input').type('{backspace}'.repeat(3));
+            cy.get('input').should('have.value', '$0,00CAD');
+    
+            cy.get('input').type('1234');
+            cy.get('input').should('have.value', '$12,34CAD');
+    
+            cy.get('input').type('{backspace}'.repeat(4));
+            cy.get('input').should('have.value', '$0,00CAD');
+    
+            cy.get('input').type('6666');
+            cy.get('input').should('have.value', '$66,66CAD');
+          }
+        );
+    
+        it(
+          'should format hundreds',
+          () => {
+            cy.get('input').type('12345');
+            cy.get('input').should('have.value', '$123,45CAD');
+    
+            cy.get('input').type('{backspace}'.repeat(5));
+            cy.get('input').should('have.value', '$0,00CAD');
+    
+            cy.get('input').type('66699');
+            cy.get('input').should('have.value', '$666,99CAD');
+          }
+        );
       }
     );
-
-    it(
-      'should format when input was created',
-      () => {
-        cy.get('input').should('have.value', '$0,00CAD');
-      }
-    );
-
-    it(
-      'shouldn\'t allow type a letter',
-      () => {
-        cy.get('input').type('abc');
-        cy.get('input').should('have.value', '$0,00CAD');
-      }
-    );
-
-    it(
-      'should format when type only cents',
-      () => {
-        cy.get('input').type('1');
-        cy.get('input').should('have.value', '$0,01CAD');
-
-        cy.get('input').type('{backspace}');
-        cy.get('input').should('have.value', '$0,00CAD');
-
-        cy.get('input').type('12');
-        cy.get('input').should('have.value', '$0,12CAD');
-
-        cy.get('input').type('{backspace}'.repeat(2));
-        cy.get('input').should('have.value', '$0,00CAD');
-
-        cy.get('input').type('66');
-        cy.get('input').should('have.value', '$0,66CAD');
-      }
-    );
-
-    it(
-      'should format dozens',
-      () => {
-        cy.get('input').type('123');
-        cy.get('input').should('have.value', '$1,23CAD');
-
-
-        cy.get('input').type('{backspace}'.repeat(3));
-        cy.get('input').should('have.value', '$0,00CAD');
-
-        cy.get('input').type('1234');
-        cy.get('input').should('have.value', '$12,34CAD');
-
-        cy.get('input').type('{backspace}'.repeat(4));
-        cy.get('input').should('have.value', '$0,00CAD');
-
-        cy.get('input').type('6666');
-        cy.get('input').should('have.value', '$66,66CAD');
-      }
-    );
-
-    it(
-      'should format hundreds',
-      () => {
-        cy.get('input').type('12345');
-        cy.get('input').should('have.value', '$123,45CAD');
-
-        cy.get('input').type('{backspace}'.repeat(5));
-        cy.get('input').should('have.value', '$0,00CAD');
-
-        cy.get('input').type('66699');
-        cy.get('input').should('have.value', '$666,99CAD');
+    
+    describe(
+      'wrong behaviour prefix and suffix with space',
+      () => {	
+        beforeEach(
+          () => {
+            cy.visit(getUrl({ prefix: '$ ', suffix: ' CAD' }));
+            cy.reload();
+          }
+        );
+    
+        it(
+          'should format when input was created',
+          () => {
+            cy.get('input').should('have.value', '$ 0,00 CAD');
+          }
+        );
+    
+        it(
+          'shouldn\'t allow type a letter',
+          () => {
+            cy.get('input').type('abc');
+            cy.get('input').should('have.value', '$ 0,00 CAD');
+          }
+        );
+    
+        it(
+          'should format when type only cents',
+          () => {
+            cy.get('input').type('1');
+            cy.get('input').should('have.value', '$ 0,01 CAD');
+    
+            cy.get('input').type('{backspace}');
+            cy.get('input').should('have.value', '$ 0,00 CAD');
+    
+            cy.get('input').type('12');
+            cy.get('input').should('have.value', '$ 0,12 CAD');
+    
+            cy.get('input').type('{backspace}'.repeat(2));
+            cy.get('input').should('have.value', '$ 0,00 CAD');
+    
+            cy.get('input').type('66');
+            cy.get('input').should('have.value', '$ 0,66 CAD');
+          }
+        );
+    
+        it(
+          'should format dozens',
+          () => {
+            cy.get('input').type('123');
+            cy.get('input').should('have.value', '$ 1,23 CAD');
+    
+    
+            cy.get('input').type('{backspace}'.repeat(3));
+            cy.get('input').should('have.value', '$ 0,00 CAD');
+    
+            cy.get('input').type('1234');
+            cy.get('input').should('have.value', '$ 12,34 CAD');
+    
+            cy.get('input').type('{backspace}'.repeat(4));
+            cy.get('input').should('have.value', '$ 0,00 CAD');
+    
+            cy.get('input').type('6666');
+            cy.get('input').should('have.value', '$ 66,66 CAD');
+          }
+        );
+    
+        it(
+          'should format hundreds',
+          () => {
+            cy.get('input').type('12345');
+            cy.get('input').should('have.value', '$ 123,45 CAD');
+    
+            cy.get('input').type('{backspace}'.repeat(5));
+            cy.get('input').should('have.value', '$ 0,00 CAD');
+    
+            cy.get('input').type('66699');
+            cy.get('input').should('have.value', '$ 666,99 CAD');
+          }
+        );
       }
     );
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-mask-money",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-mask-money",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-mask-money",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "private": false,
   "description": "Simple money mask developed with pure JavaScript. To run on Client Side and Server Side",
   "types": "./lib/simple-mask-money.d.ts",

--- a/src/set-mask.ts
+++ b/src/set-mask.ts
@@ -155,7 +155,7 @@ function setMask(
         continue;
       }
 
-      if (Number.isNaN(Number(character))) continue;
+      if (Number.isNaN(Number(character)) || character === ' ') continue;
 
       thousandsCounter -= 1;
 

--- a/tests/set-mask.test.ts
+++ b/tests/set-mask.test.ts
@@ -199,6 +199,17 @@ describe(
             expect(input.value).toBe('R$0,69BRL');
           },
         );
+
+        it(
+          'should format when type cents only and prefix has space', 
+          () => {
+            clear = setMask(input, { prefix: 'R$ ', suffix: ' BRL' });
+    
+            write('69');
+    
+            expect(input.value).toBe('R$ 0,69 BRL');
+          },
+        );
         
         it(
           'should format when type cents and dozens', 
@@ -208,6 +219,17 @@ describe(
             write('666');
     
             expect(input.value).toBe('R$6,66BRL');
+          },
+        );
+
+        it(
+          'should format when type cents and dozens and prefix has space', 
+          () => {
+            clear = setMask(input, { prefix: 'R$ ', suffix: ' BRL' });
+    
+            write('666');
+    
+            expect(input.value).toBe('R$ 6,66 BRL');
           },
         );
         
@@ -221,6 +243,17 @@ describe(
             expect(input.value).toBe('R$6.669,99BRL');
           },
         );
+
+        it(
+          'should format when type thousands', 
+          () => {
+            clear = setMask(input, { prefix: 'R$ ', suffix: ' BRL' });
+    
+            write('666999');
+    
+            expect(input.value).toBe('R$ 6.669,99 BRL');
+          },
+        );
         
         it(
           'should format when type number sequentialy', 
@@ -230,6 +263,17 @@ describe(
             write('1234567');
     
             expect(input.value).toBe('R$12.345,67BRL');
+          },
+        );
+        
+        it(
+          'should format when type number sequentialy', 
+          () => {
+            clear = setMask(input, { prefix: 'R$ ', suffix: ' BRL' });
+    
+            write('1234567');
+    
+            expect(input.value).toBe('R$ 12.345,67 BRL');
           },
         );
       }


### PR DESCRIPTION
# 📝 Description

Should fix problem reported by @fernandoamaral at issue #70!

## 🔎 Evidence that this works

**Before:**
![evidence](https://github.com/codermarcos/simple-mask-money/assets/12430365/6fd46fe1-12e5-42bd-8f23-96514710f0f6)

**After**

![evidence](https://github.com/codermarcos/simple-mask-money/assets/12430365/914cd32d-949d-450a-9907-67b766ef3a93)

## 🧪 How to validate

Run the application using [vercel preview](https://dashboard-git-fix-%2370-problem-with-space-in-prefix):

- [ ] Should keep formatation when add a number and has space in prefix


## 🏷️ Related tasks

- #70

### 🗃️ Changes

On branch:

> **fix/#70/problem-with-space-in-prefix**


Changes to be committed:

> modified:   cypress/e2e/v4.x.x/set-mask.cy.ts
modified:   tests/set-mask.test.ts
modified:   src/set-mask.ts