### PR TITLE
Don't capture `Tab`  key press

### DIFF
--- a/src/set-mask.ts
+++ b/src/set-mask.ts
@@ -226,6 +226,9 @@ function setMask(
     // Trigger input submit
     if (e.key === 'Enter') return;
 
+    // Allow focus change
+    if (e.key === 'Tab') return;
+
     // Select all
     if (e.ctrlKey && e.key === 'a') return setCaretPosition([firstPositionToNumber, lastPositionToNumber]);
 


### PR DESCRIPTION
# 📝 Description
<!-- Describe here the changes, if it is link issues here and another pull requests -->
Trying to focus on next input doesn't work because simple-mask-money is capturing tab key presses. This issue is similar to  https://github.com/codermarcos/simple-mask-money/issues/67

I tried to implement a test for this case but it seems cypress doesn't support Tab key press properly (even using cypress-plugin-tab or cypress-real-events packages):
- https://docs.cypress.io/api/commands/type#Typing-tab-key-does-not-work
- https://github.com/cypress-io/cypress/issues/299

But I implemented a test using Playright on my local dev and I could reproduce the failing case and fix it with this patch.

Before patch:
<img width="979" alt="Screenshot 2024-12-27 at 13 39 52" src="https://github.com/user-attachments/assets/820b474b-4faf-4793-b8ee-bba4f75eefff" />

After patch:
<img width="1023" alt="Screenshot 2024-12-27 at 13 40 08" src="https://github.com/user-attachments/assets/a546d414-c244-470f-9757-ceda8db157fb" />

The test code:
```javascript
test('allow focus change', async ({ page }) => {
  await page.goto('./e2e/index.html');

  await expect(page.getByTestId('input')).not.toBeFocused()
  await page.locator('input').focus()
  await expect(page.getByTestId('input')).toBeFocused()
  await page.keyboard.press('1')
  await page.keyboard.press('Tab');
  await expect(page.getByTestId('input')).not.toBeFocused()
});
``` 